### PR TITLE
Fixing readline support for macOS

### DIFF
--- a/arduino_dbg/repl.py
+++ b/arduino_dbg/repl.py
@@ -3,9 +3,13 @@
 import functools
 import os
 import os.path
-import readline
 import signal
 import traceback
+
+try:
+   import gnureadline as readline
+except ImportError:
+   import readline
 
 import arduino_dbg.debugger as dbg
 import arduino_dbg.dump as dump

--- a/arduino_dbg/repl_command.py
+++ b/arduino_dbg/repl_command.py
@@ -8,11 +8,15 @@ Methods to tokenize command input, and print per-command help messages.
 import inspect
 import os
 import os.path
-import readline
 import shlex
 from sortedcontainers import SortedDict, SortedList
 import sys
 import traceback
+
+try:
+   import gnureadline as readline
+except ImportError:
+   import readline
 
 import arduino_dbg.term as term
 from arduino_dbg.term import MsgLevel

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     pyelftools >= 0.27
     pyserial >= 3.5
     sortedcontainers >= 2.4.0
+    gnureadline >= 6.3.8 ; platform_system=="Darwin"
 
 python_requires = >=3.6
 zip_safe = True


### PR DESCRIPTION
macOS uses Editline (libedit) rather than GNU Readline, so certain methods in Python's `readline` module will throw exceptions, a few of which are not caught and cause this utility to exit.

This adds a dependency on the [`gnureadline` module](https://github.com/ludwigschwardt/python-gnureadline) for macOS platforms.